### PR TITLE
Rauaq Arlin - Code Refactor

### DIFF
--- a/click-to-reveal/script.js
+++ b/click-to-reveal/script.js
@@ -16,43 +16,40 @@ const questions = [
 window.addEventListener("DOMContentLoaded", (event) => {
     console.log("DOM fully loaded and parsed");
 
-   let btnContainer =  document.getElementById("idt-btn-container")
-   for(let i = 0; i < questions.length; i++){
+    let btnContainer = document.getElementById("idt-btn-container")
+    for (let i = 0; i < questions.length; i++) {
         btnContainer.innerHTML += `<button>${questions[i].question}</button>`
-   }
+    }
 
-    const buttons = document.getElementsByTagName('button');
+    const buttons = btnContainer.getElementsByTagName('button');
     console.log(buttons);
 
-    let y = buttons.length + 1
-
+    // Loop through all buttons
+    // Remove "idt-active-btn" from all other buttons
+    // Add "idt-active-btn" to the current/clicked button
     for (let x = 0; x < buttons.length; x++) {
-        
-
-
         buttons[x].addEventListener("click", (event) => {
-
-            
-            buttons[x].classList.add("idt-active-btn");
-
-
             console.log(`button clicked ${x}`);
-
-
+            deactivateAllButtons(buttons);
+            activateButton(buttons[x]);
             textChange(questions[x].answer);
-
-            if(y < buttons.length + 1){
-            buttons[y].classList.remove("idt-active-btn");
-    
-            };
-
-            y = x
-        }
-        )
-    
+        });
     }
 });
 
-function textChange(url) {
-    document.getElementById('container').innerHTML = `<p> ${url} </p>`
+// Add "idt-active-btn" to the current/clicked button
+function activateButton(button) {
+    button.classList.add("idt-active-btn");
+}
+
+// Remove "idt-active-btn" from all other buttons
+function deactivateAllButtons(buttons) {
+    for (let x = 0; x < buttons.length; x++) {
+        buttons[x].classList.remove("idt-active-btn");
+    }
+}
+
+// Change the text in the container
+function textChange(text) {
+    document.getElementById('container').innerHTML = `<p> ${text} </p>`
 }


### PR DESCRIPTION
- refactored the code that was adding and removing `idt-btn-container`
- previously, there was a `y` variable being used that was a bit confusing
- by taking an approach of de-activating all other buttons first, **then** adding `"dt-btn-container` the code is a bit more readable
- we also broke out two small functions which follows the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single-responsibility_principle)
- no visual changes were made, everything should look the same

This is what the current page looks like:
![image](https://user-images.githubusercontent.com/553767/231219313-0d07a0a9-c55e-400a-b429-cad2784c542d.png)
